### PR TITLE
Parse GetItemResponse for recurring CalendarItems

### DIFF
--- a/elements/Offset.go
+++ b/elements/Offset.go
@@ -2,11 +2,15 @@ package elements
 
 // The Offset element describes the offset from the BaseOffset. Together with the BaseOffset element, the Offset element identifies whether the time is standard or daylight saving time.
 // https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/offset
-import "encoding/xml"
+import (
+	"encoding/xml"
+
+	"github.com/sosodev/duration"
+)
 
 type Offset struct {
 	XMLName xml.Name
-	TEXT    int64 `xml:",chardata"`
+	TEXT    duration.Duration `xml:",chardata"`
 }
 
 func (O *Offset) SetForMarshal() {

--- a/elements/TimeTimeChangeType.go
+++ b/elements/TimeTimeChangeType.go
@@ -2,9 +2,10 @@ package elements
 
 // The Time element describes the time when the time changes between standard time and daylight saving time.
 // https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/time-timechangetype
-import "time"
-
-import "encoding/xml"
+import (
+	"encoding/xml"
+	"time"
+)
 
 type TimeTimeChangeType struct {
 	XMLName xml.Name
@@ -17,4 +18,22 @@ func (T *TimeTimeChangeType) SetForMarshal() {
 
 func (T *TimeTimeChangeType) GetSchema() *Schema {
 	return &SchemaTypes
+}
+
+func (T *TimeTimeChangeType) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	var s string
+
+	if err := d.DecodeElement(&s, &start); err != nil {
+		return err
+	}
+
+	// Parse using the TimeOnly layout: "15:04:05"
+	t, err := time.Parse(time.TimeOnly, s)
+	if err != nil {
+		return err
+	}
+
+	T.TEXT = t
+
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 )
 
 require (
+	github.com/sosodev/duration v1.4.0 // indirect
 	golang.org/x/crypto v0.2.0 // indirect
 	golang.org/x/sys v0.2.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/sosodev/duration v1.4.0 h1:35ed0KiVFriGHHzZZJaZLgmTEEICIyt8Sx0RQfj9IjE=
+github.com/sosodev/duration v1.4.0/go.mod h1:RQIBBX0+fMLc/D9+Jb/fwvVmo0eZvDDEERAikUR6SDg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=


### PR DESCRIPTION
Durations and Time were in a different format than the XML unmarshal assumed.
With these commits all my calendar entries are now parsed correctly and without issues.